### PR TITLE
✨ ♻️ Simple Firestore DSL and other minor improvements

### DIFF
--- a/firestore/src/main/scala/me/wojnowski/googlecloud4s/firestore/FirestoreDsl.scala
+++ b/firestore/src/main/scala/me/wojnowski/googlecloud4s/firestore/FirestoreDsl.scala
@@ -1,0 +1,86 @@
+package me.wojnowski.googlecloud4s.firestore
+
+import me.wojnowski.googlecloud4s.firestore.Firestore.FieldFilter
+import me.wojnowski.googlecloud4s.firestore.Firestore.Order
+import fs2.Stream
+import Firestore.Error
+import cats.data.NonEmptyList
+import cats.data.NonEmptyMap
+
+object FirestoreDsl {
+
+  implicit class FirestoreOps[F[_]](firestore: Firestore[F]) {
+    def collection(collectionId: CollectionId): CollectionReferenceWithFirestore[F] =
+      CollectionReferenceWithFirestore(firestore.rootReference.collection(collectionId), firestore)
+
+    def /(collectionId: CollectionId): CollectionReferenceWithFirestore[F] = collection(collectionId)
+  }
+
+  case class CollectionReferenceWithFirestore[F[_]](collection: Reference.Collection, firestore: Firestore[F])
+    extends CollectionReferenceOps[F] {
+    def document(documentId: DocumentId): DocumentReferenceWithFirestore[F] =
+      DocumentReferenceWithFirestore(collection.document(documentId), firestore)
+
+    def /(documentId: DocumentId): DocumentReferenceWithFirestore[F] = document(documentId)
+  }
+
+  case class DocumentReferenceWithFirestore[F[_]](document: Reference.Document, firestore: Firestore[F]) extends DocumentReferenceOps[F] {
+    def collection(collectionId: CollectionId): CollectionReferenceWithFirestore[F] =
+      CollectionReferenceWithFirestore(document.collection(collectionId), firestore)
+
+    def /(collectionId: CollectionId): CollectionReferenceWithFirestore[F] = collection(collectionId)
+  }
+
+  implicit class ImplicitCollectionReferenceOps[F[_]: Firestore](val collection: Reference.Collection) extends CollectionReferenceOps[F] {
+    def firestore: Firestore[F] = Firestore[F]
+  }
+
+  implicit class ImplicitDocumentReferenceOps[F[_]: Firestore](val document: Reference.Document) {
+    def firestore: Firestore[F] = Firestore[F]
+  }
+
+  trait CollectionReferenceOps[F[_]] {
+
+    def collection: Reference.Collection
+
+    def firestore: Firestore[F]
+
+    def add[V: FirestoreCodec](value: V): F[Reference.Document] = firestore.add(collection, value)
+
+    def stream[V: FirestoreCodec](
+      filters: List[FieldFilter] = List.empty,
+      orderBy: List[Order] = List.empty,
+      pageSize: Int = 50
+    ): Stream[F, (Reference.Document, Either[Error.DecodingFailure, V])] =
+      firestore.stream(collection, filters, orderBy, pageSize)
+
+    def streamLogFailures[V: FirestoreCodec](
+      filters: List[FieldFilter] = List.empty,
+      orderBy: List[Order] = List.empty,
+      pageSize: Int = 50
+    ): Stream[F, (Reference.Document, V)] =
+      firestore.streamLogFailures(collection, filters, orderBy, pageSize)
+
+    def batchGet[V: FirestoreCodec](ids: NonEmptyList[DocumentId]): F[NonEmptyMap[Reference.Document, Option[V]]] =
+      firestore.batchGet(ids.map(id => collection.document(id)))
+
+  }
+
+  trait DocumentReferenceOps[F[_]] {
+    def document: Reference.Document
+    def firestore: Firestore[F]
+
+    def set[V: FirestoreCodec](value: V): F[Unit] = firestore.set(document, value)
+
+    def get[V: FirestoreCodec]: F[Option[V]] = firestore.get(document)
+
+    def update[V: FirestoreCodec](f: V => V): F[Option[V]] = firestore.update(document, f)
+
+    def delete: F[Unit] = firestore.delete(document)
+  }
+
+  implicit class BatchGetOps[F[_]](references: NonEmptyList[Reference.Document])(implicit firestore: Firestore[F]) {
+    def batchGet[V: FirestoreCodec]: F[NonEmptyMap[Reference.Document, Option[V]]] = firestore.batchGet(references)
+  }
+
+}

--- a/firestore/src/test/scala/me/wojnowski/googlecloud4s/firestore/OptimisticLockingTest.scala
+++ b/firestore/src/test/scala/me/wojnowski/googlecloud4s/firestore/OptimisticLockingTest.scala
@@ -26,7 +26,7 @@ class OptimisticLockingTest extends CatsEffectSuite with TestContainerForAll wit
 
   val projectId: ProjectId = ProjectId("project-id")
 
-  val collection = "collection-a".toCollectionId
+  val collection = Reference.Root(projectId).collection("collection-a".toCollectionId)
 
   import FirestoreCodec.circe._
 

--- a/firestore/src/test/scala/me/wojnowski/googlecloud4s/firestore/ReferenceTest.scala
+++ b/firestore/src/test/scala/me/wojnowski/googlecloud4s/firestore/ReferenceTest.scala
@@ -17,7 +17,10 @@ class ReferenceTest extends FunSuite {
     val rawName = "projects/project-id/databases/(default)/documents/root-collection/Gh5Efo66qP8fRg4L2fuY"
     val result = Reference.parse(rawName)
     val expected =
-      Reference.Document(Reference.Root(ProjectId("project-id")), "root-collection".toCollectionId, "Gh5Efo66qP8fRg4L2fuY".toDocumentId)
+      Reference.Document(
+        Reference.Collection(Reference.Root(ProjectId("project-id")), "root-collection".toCollectionId),
+        "Gh5Efo66qP8fRg4L2fuY".toDocumentId
+      )
     assertEquals(result, Right(expected))
   }
 
@@ -39,16 +42,22 @@ class ReferenceTest extends FunSuite {
     val result = Reference.parse(rawName)
     val expected =
       Reference.Document(
-        Reference.Document(
+        Reference.Collection(
           Reference.Document(
-            Reference.Root(ProjectId("project-id")),
-            "collection-a".toCollectionId,
-            "document-a".toDocumentId
+            Reference.Collection(
+              Reference.Document(
+                Reference.Collection(
+                  Reference.Root(ProjectId("project-id")),
+                  "collection-a".toCollectionId
+                ),
+                "document-a".toDocumentId
+              ),
+              "collection-b".toCollectionId
+            ),
+            "document-b".toDocumentId
           ),
-          "collection-b".toCollectionId,
-          "document-b".toDocumentId
+          "collection-c".toCollectionId
         ),
-        "collection-c".toCollectionId,
         "document-c".toDocumentId
       )
     assertEquals(result, Right(expected))
@@ -75,16 +84,22 @@ class ReferenceTest extends FunSuite {
 
   test("Path.Document toString") {
     val path = Reference.Document(
-      Reference.Document(
+      Reference.Collection(
         Reference.Document(
-          Reference.Root(ProjectId("project-id")),
-          "collection-a".toCollectionId,
-          "document-a".toDocumentId
+          Reference.Collection(
+            Reference.Document(
+              Reference.Collection(
+                Reference.Root(ProjectId("project-id")),
+                "collection-a".toCollectionId
+              ),
+              "document-a".toDocumentId
+            ),
+            "collection-b".toCollectionId
+          ),
+          "document-b".toDocumentId
         ),
-        "collection-b".toCollectionId,
-        "document-b".toDocumentId
+        "collection-c".toCollectionId
       ),
-      "collection-c".toCollectionId,
       "document-c".toDocumentId
     )
 
@@ -101,8 +116,8 @@ class ReferenceTest extends FunSuite {
 
     val path = Reference.Root(ProjectId("project-id"))
 
-    val result = path.resolve(collectionId, documentId)
-    val expected = Reference.Document(path, collectionId, documentId)
+    val result = path.collection(collectionId).document(documentId)
+    val expected = Reference.Document(Reference.Collection(path, collectionId), documentId)
     assertEquals(result, expected)
   }
 
@@ -113,10 +128,20 @@ class ReferenceTest extends FunSuite {
     val documentBId = "document-a".toDocumentId
 
     val rootPath = Reference.Root(ProjectId("project-id"))
-    val path = Reference.Document(rootPath, collectionAId, documentAId)
+    val path = Reference.Document(Reference.Collection(rootPath, collectionAId), documentAId)
 
-    val result = path.resolve(collectionBId, documentBId)
-    val expected = Reference.Document(Reference.Document(rootPath, collectionAId, documentAId), collectionBId, documentBId)
+    val result = path.collection(collectionBId).document(documentBId)
+    val expected =
+      Reference.Document(
+        Reference.Collection(
+          Reference.Document(
+            Reference.Collection(rootPath, collectionAId),
+            documentAId
+          ),
+          collectionBId
+        ),
+        documentBId
+      )
     assertEquals(result, expected)
   }
 


### PR DESCRIPTION
* Adds `Reference.Collection`
* Adds Firestore DSL (e.g. `(firestore / collectionA / documentX / collectionB / documentY).set(value)`)
* Renames `Firestore.put` to `Firestore.set`
* Removes `Firestore` methods using collection/document IDs and parents instead of references