### PR TITLE
🐛 Use non-URL-safe base64 encoding/decoding

### DIFF
--- a/firestore/src/main/scala/me/wojnowski/googlecloud4s/firestore/Value.scala
+++ b/firestore/src/main/scala/me/wojnowski/googlecloud4s/firestore/Value.scala
@@ -80,7 +80,7 @@ object Value {
         case List(("bytesValue", value))     =>
           value
             .as[java.lang.String]
-            .flatMap(string => Try(Base64.getUrlDecoder.decode(string)).toEither)
+            .flatMap(string => Try(Base64.getDecoder.decode(string)).toEither)
             .leftMap(_.getMessage)
             .map(Bytes.apply)
         case List(("referenceValue", value)) =>
@@ -122,7 +122,7 @@ object Value {
         case Double(value)                 => value.asJson
         case Timestamp(value)              => value.asJson
         case String(value)                 => value.asJson
-        case Bytes(value)                  => new java.lang.String(Base64.getUrlEncoder.encode(value)).asJson
+        case Bytes(value)                  => new java.lang.String(Base64.getEncoder.encode(value)).asJson
         case Reference(value)              => value.full.asJson
         case GeoPoint(latitude, longitude) =>
           JsonObject(


### PR DESCRIPTION
It seems Firestore expects regular Base64, not Base64(URL). Discovered by trial and error, but also described here: https://barvysta.medium.com/firebase-storage-base64url-string-you-are-going-to-have-troubles-40be1ef56521

Curiously enough, Google's documentation ([Firestore documentation](https://cloud.google.com/firestore/docs/reference/rest/Shared.Types/ArrayValue#Value) leading to [type and format summary](https://developers.google.com/discovery/v1/type-format)) states the opposite 🤷‍♂️ 
> A padded, base64-encoded string of bytes, encoded with a URL and filename safe alphabet (sometimes referred to as "web-safe" or "base64url"). Defined by [RFC4648](http://tools.ietf.org/html/rfc4648).

But following Java Firestore implementation leads to [protobuf](https://github.com/protocolbuffers/protobuf/blob/6fe5c6fd8e270e3771e31f94f08895475ee5b216/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L1239), which uses [`base64`](https://guava.dev/releases/17.0/api/docs/com/google/common/io/BaseEncoding.html#base64()), not [`base64Url`](https://guava.dev/releases/17.0/api/docs/com/google/common/io/BaseEncoding.html#base64Url()).